### PR TITLE
Fix with unicode symbols

### DIFF
--- a/src/distance.rs
+++ b/src/distance.rs
@@ -8,9 +8,9 @@ fn min3<T: Ord>(v1: T, v2: T, v3: T) -> T {
 #[allow(clippy::needless_range_loop)]
 pub fn levenshtein(lhs: &str, rhs: &str) -> usize {
     let l_vec = lhs.chars().collect::<Vec<_>>();
-    let l_len = lhs.len();
+    let l_len = l_vec.len();
     let r_vec = rhs.chars().collect::<Vec<_>>();
-    let r_len = rhs.len();
+    let r_len = r_vec.len();
 
     if l_len == 0 {
         return r_len;


### PR DESCRIPTION
Prevent this type of error:
```
thread 'main' panicked at /home/violette/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/fuzzy-search-0.1.0/src/distance.rs:32:48:
index out of bounds: the len is 1 but the index is 1
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```